### PR TITLE
Fix neutron cleanup order to delete routers before networks

### DIFF
--- a/rally_openstack/task/cleanup/resources.py
+++ b/rally_openstack/task/cleanup/resources.py
@@ -436,6 +436,10 @@ class NeutronPort(NeutronMixin):
             LOG.debug(f"Port {self.id()} was not deleted. Skip silently "
                       f"because port can be already auto-deleted.")
 
+@base.resource("neutron", "router", order=next(_neutron_order),
+               tenant_resource=True)
+class NeutronRouter(NeutronMixin):
+    pass
 
 @base.resource("neutron", "subnet", order=next(_neutron_order),
                tenant_resource=True)
@@ -446,12 +450,6 @@ class NeutronSubnet(NeutronMixin):
 @base.resource("neutron", "network", order=next(_neutron_order),
                tenant_resource=True)
 class NeutronNetwork(NeutronMixin):
-    pass
-
-
-@base.resource("neutron", "router", order=next(_neutron_order),
-               tenant_resource=True)
-class NeutronRouter(NeutronMixin):
     pass
 
 


### PR DESCRIPTION
Routers with external gateways have ports on external networks. The previous cleanup order (subnet, network, router) caused network deletion to fail because the gateway port was still in use. Moving router cleanup before subnet/network ensures gateway and interface ports are removed first.
Closes-Bug: #2144753